### PR TITLE
Outputs for performance analysis

### DIFF
--- a/client_log
+++ b/client_log
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE log SYSTEM "logger.dtd">
-<log>
-</log>

--- a/client_log.1
+++ b/client_log.1
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE log SYSTEM "logger.dtd">
-<log>
-</log>

--- a/client_log.2
+++ b/client_log.2
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE log SYSTEM "logger.dtd">
-<log>
-</log>

--- a/client_log.3
+++ b/client_log.3
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE log SYSTEM "logger.dtd">
-<log>
-</log>

--- a/src/main/java/com/distributed/p2pClient/Main.java
+++ b/src/main/java/com/distributed/p2pClient/Main.java
@@ -72,7 +72,8 @@ public class Main {
               "download <filename> : Download the file from the Grid",
               "routes              : Print routing table of the node",
               "help                : Show help screen",
-              "exit                : Remove the current node from the Grid and exit");
+              "exit                : Remove the current node from the Grid and exit",
+              "stats:              : Get system stats");
       Scanner scanner = new Scanner(System.in);
         while (true){
             System.out.println();
@@ -107,6 +108,7 @@ public class Main {
                     client.printRoutingTable();
                     break;
                 case "search":
+                    long start = System.currentTimeMillis();
                     Future<List<String>> queryResultFuture = client.searchForFile(fileName);
                     List<String> queryResult = queryResultFuture.get();
                     if (queryResult.size() != 0) {
@@ -117,6 +119,8 @@ public class Main {
                     else {
                         System.out.println(">> No matching files found");
                     }
+                    long elapsedTime = System.currentTimeMillis() - start;
+                    System.out.printf("Elapsed Time : %d ms", elapsedTime);
                     break;
                 case "download":
                     Future<FileDownloadResult> downloadResponseFuture = client.downloadFile(fileName);

--- a/src/main/java/com/distributed/p2pClient/Main.java
+++ b/src/main/java/com/distributed/p2pClient/Main.java
@@ -140,6 +140,12 @@ public class Main {
                         System.out.println(">> Couldn't find an exact match for the filename");
                     }
                     break;
+                case "stats":
+                    long ser = client.getNumberOfQueriesReceived();
+                    long fwd = client.getNumberOfQueriesDispatched();
+                    long ans = client.getAnsweredQueryCount();
+                    System.out.printf("SER-%d FWD-%d ANS-%d%n", ser, fwd, ans);
+                    break;
                 default:
                     System.out.println("Illegal command");
                     System.out.println(helpString);

--- a/src/main/java/com/distributed/p2pFileTransfer/AbstractFileTransferService.java
+++ b/src/main/java/com/distributed/p2pFileTransfer/AbstractFileTransferService.java
@@ -156,6 +156,14 @@ public abstract class AbstractFileTransferService {
     return this.queryDispatcher.getDispatchedCount();
   }
 
+  /**
+   * Print the number of search queries answered so far
+   * @return
+   */
+  public long getAnsweredQueryCount(){
+    return this.queryListener.getAnsweredCount();
+  }
+
   void stop() {
     queryListener.stop();
     try {

--- a/src/main/java/com/distributed/p2pFileTransfer/QueryListener.java
+++ b/src/main/java/com/distributed/p2pFileTransfer/QueryListener.java
@@ -226,6 +226,7 @@ class QueryListener implements Runnable {
       try {
         fileTransferService.getQueryDispatcher().dispatchOne(joinOk).get();
         logger.log(Level.INFO, String.format("join ok to node %s", other.toString()));
+        incrementAnsweredCount();
       } catch (InterruptedException e) {
         e.printStackTrace();
       } catch (ExecutionException e) {

--- a/src/main/java/com/distributed/p2pFileTransfer/QueryListener.java
+++ b/src/main/java/com/distributed/p2pFileTransfer/QueryListener.java
@@ -18,6 +18,7 @@ class QueryListener implements Runnable {
   private final HashMap<Node, List<Executor>> pendingExecutors;
   private Logger logger;
   private long queryCount = 0;
+  private long answeredCount = 0;
   private final Set<String> pendingSearchQueries = ConcurrentHashMap.newKeySet();
 
   public QueryListener(AbstractFileTransferService fileTransferService, int port)
@@ -87,12 +88,20 @@ class QueryListener implements Runnable {
     }
   }
 
+  private synchronized void incrementAnsweredCount(){
+    this.answeredCount++;
+  }
+
   public void stop() {
     terminate = true;
   }
 
   public long getQueryCount() {
     return queryCount;
+  }
+
+  public long getAnsweredCount(){
+    return answeredCount;
   }
 
   private class ListenerThread implements Runnable {
@@ -191,6 +200,7 @@ class QueryListener implements Runnable {
       try {
         QueryResult result =
             fileTransferService.getQueryDispatcher().dispatchOne(responseQuery).get();
+        incrementAnsweredCount();
         logger.log(
             Level.INFO,
             String.format(


### PR DESCRIPTION
Resolve #35 .
We have a problem regarding measuring the hop count

1. Current implementation don't keep track of this
2. Since we are flooding the network and combining the results
    -  Search query don't have a number a number of hops because each file have different number of hops (they are coming from multiple sources)
    -  Each file in the search result may have different number of hops (same file in multiple sources)

As a simple solution I would suggest

1. Start the system with just two nodes and do a search and get the elapsed time as t
2. For each subsequent search divide the elapsed time by t and round up get an approximation for the number of hops  